### PR TITLE
Update tutorials.rst

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -1,4 +1,4 @@
-Basic utilisation
+Basic use
 =================
 
 Installing the package
@@ -16,19 +16,19 @@ Once GScrew is installed, you should import it as following::
 	import gscrew.geometric_algebra as ga
 	from gscrew.screw import Screw, CoScrew, comoment
 
-The ``geometric_algebra`` module is a framework which provides you a n-dimensional geometric algebra and multivectors.
+The ``geometric_algebra`` module is a framework which provides you with a n-dimensional geometric algebra and multivectors.
 
 The ``screw`` module gives you three main objects:
 
-* Screw which is a class for basic screw
+* Screw, a class which implements generalized screws
 
-* CoScrew is also a class
+* CoScrew, also a class, implementing coscrews
 
-* comoment which is a function
+* comoment, a function implementing the comoment of a coscrew and a screw
 
 Initializing the framework
 --------------------------
-Before manipulating screws, you need to initialize to geometric algebra in which you will work. For the exemple, we work with a three-dimensionnal one but the module can handle n-dimensionnal algebra::
+Before manipulating screws, you need to initialize the geometric algebra in which you will work. For the exemple, we work with a three-dimensionnal one but the module can handle n-dimensional algebras::
 
 	my_algebra = ga.GeometricAlgebra(3)
 	locals().update(my_algebra.blades)
@@ -37,13 +37,13 @@ On the first line, we create a new three-dimensional algebra. On the second one 
 
 Finally creating a screw
 ------------------------
-Once the geometric algebra have been initialized, you can start to work with screws. Each screws (this also applies to coscrews) is composed of three elements:
+Once the geometric algebra has been initialized, you can start working with screws. Each screw (this also applies to coscrews) is composed of three elements:
 
-* the reference point to which the screw is expressed
+* the reference point at which the screw is expressed
 
 * the direction of the screw (which is independent of the reference point)
 
-* the moment of the screw (depend of the point)
+* the moment of the screw (which depends on the reference point)
 
 .. note:: The ``Screw`` and ``CoScrew`` classes inherit from a more general class: ``ScrewBase``. So when a manipulation or a method is introduced as a ``ScrewBase`` method, it will operate on ``Screw`` and ``CoScrew`` classes.
 
@@ -54,18 +54,18 @@ So let's see a small exemple::
 	M1 = 2*e2    # this is a simple vector
 	screw1 = Screw(A, S, M)
 
-To display a screw, you can print it, but it is recommand to use the method ``ScrewBase.show``. Indeed, the moment of a screw depends on the reference point choosen, by using ``ScrewBase.show`` you can pass the point on which you want to display the screw::
+To display a screw, you can print it, but it is recommended to use the method ``ScrewBase.show``. Indeed, the moment of a screw depends on the chosen point of reduction, so by using ``ScrewBase.show`` you can pass the point at which you want to display the screw::
 
 	screw1.show()  # will display the screw on the reference point, here A
 	screw1.show(0 * e0)  # will display the screw on the origin of the reference frame
 
 .. note::
-	``print`` will display the screw at it's reference point.
+	``print`` will display the screw at its reference point.
 
 You can also change the reference point of a screw by using ``ScrewBase.change_point``::
 	
 	B = e1 - e2  # let be B a new point
 	screw2 = screw1.change_point(B)
-	print(screw1 ^ screw2)  # return a null screw
+	print(screw1 ^ screw2)  # returns the zero screw
 
-In that case, ``screw1`` and ``screw2`` are the same screw but not expressed at the same point. So the straight line passing the two screws does not exist, hence the null screw.
+In this case, for example, ``screw1`` and ``screw2`` are the same 1-screw but are not expressed at the same point. So the straight line joining these two 1-screws does not exist, hence the zero screw.


### PR DESCRIPTION
Minor spelling corrections on the 'Basic use' paragraph Note: the zero element of the screw algebra is called the 'zero screw' and not the 'null screw' (although we say 'torseur nul' in French). Null elements of an associative algebra usually refer to elements whose square is zero